### PR TITLE
Ability to set time travel option in Hive Metastore catalog for HMS-managed Delta Lake tables.

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaTableV2.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaTableV2.scala
@@ -69,7 +69,12 @@ case class DeltaTableV2(
   private lazy val (rootPath, partitionFilters, timeTravelByPath) = {
     if (catalogTable.isDefined) {
       // Fast path for reducing path munging overhead
-      (new Path(catalogTable.get.location), Nil, None)
+      if (timeTravelOpt.isDefined) { // time travel option overrides catalog settings
+        (new Path(catalogTable.get.location), Nil, None)
+      } else { // retrieve time travel from catalog table stricture serde properties
+        (new Path(catalogTable.get.location), Nil,
+          DeltaDataSource.getTimeTravelVersion(catalogTable.get.storage.properties))
+      }
     } else {
       DeltaDataSource.parsePathIdentifier(spark, path.toString, options)
     }


### PR DESCRIPTION
Ability to set time travel option in Hive Metastore catalog for HMS-managed Delta Lake tables.
see https://github.com/delta-io/delta/issues/2163